### PR TITLE
Update MutationsPsionicShield.xml

### DIFF
--- a/Defs/Radiology/MutationsPsionicShield.xml
+++ b/Defs/Radiology/MutationsPsionicShield.xml
@@ -105,7 +105,7 @@
   </RadiologyEffectSpawnerDef>
 
   <HediffDef Abstract="True" Name="RadiologyPsionicShieldBase" ParentName="RadiologyMutation">
-    <description>NAME has formed a psionic shield around self, allowing for protection from both ranged and melee damage.</description>
+    <description>NAME has formed a psionic shield around HIMself, allowing for protection from both ranged and melee damage.</description>
     <relatedParts><li>Head</li></relatedParts>
     <affectedParts><li>Brain</li></affectedParts>
     <exclusive>psionicShield</exclusive>


### PR DESCRIPTION
This line sounded a bit odd grammatically. I think that this might sound better. "HIMself" should be corrected by Rimworld to 'himself' or 'herself' depending on the pawn.

This is my first pull request, and I am unsure of the etiquette. Apologies if I have done anything incorrectly.